### PR TITLE
fix: ne plus ignorer la conso quand l'abonnement a démarré en cours d'année

### DIFF
--- a/veolia_api/veolia_api.py
+++ b/veolia_api/veolia_api.py
@@ -289,13 +289,19 @@ class VeoliaAPI:
             "%Y-%m-%d",
         ).replace(tzinfo=UTC)
         if month is not None:
-            requested_date = datetime(year, month, 1, tzinfo=UTC)
+            if month == 12:
+                period_end = datetime(year, 12, 31, tzinfo=UTC)
+            else:
+                period_end = datetime(year, month + 1, 1, tzinfo=UTC) - timedelta(
+                    days=1,
+                )
         else:
-            requested_date = datetime(year, 1, 1, tzinfo=UTC)
+            period_end = datetime(year, 12, 31, tzinfo=UTC)
 
-        if requested_date < date_debut:
+        if period_end < date_debut:
             _LOGGER.warning(
-                "Requested data for %s-%s is before subscription start date %s. Request aborted.",
+                "Requested data for %s-%s is entirely before subscription "
+                "start date %s. Request aborted.",
                 year,
                 month,
                 self.account_data.date_debut_abonnement,


### PR DESCRIPTION
Fixes #32.

`_get_consumption_data` annulait la requête quand le début de la période demandée était antérieur à `date_debut_abonnement`. Pour les requêtes annuelles ce début est toujours le 1er janvier, donc les abonnements souscrits après janvier ne recevaient jamais de conso mensuelle et perdaient le journalier du mois de souscription.

On compare désormais la fin de la période (31/12 pour l'annuel, dernier jour du mois pour le mensuel). Le backend filtre déjà les jours antérieurs au début d'abonnement : les périodes qui chevauchent l'abonnement sont donc récupérées correctement, celles entièrement antérieures restent ignorées. Aucun changement pour les abonnements souscrits en janvier ou avant.
