### PR TITLE
feat: restore multi-portal support and add Vendee Eau (monespace85)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 VEOLIA_EMAIL=your@email.com
 VEOLIA_PASSWORD=your_password
+# Optional: portal hostname, defaults to eau.veolia.fr (see README#supported-portals)
+# VEOLIA_PORTAL_URL=monespace85.eau.veolia.fr

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,12 @@
 # Contributing
 
-Thank you for considering contributing to `veolia-api`! All contributions are welcome: bug reports, feature suggestions, and code improvements.
+Thank you for considering contributing to `veolia-api`! All contributions are welcome: bug reports, portal additions, feature suggestions, and code improvements.
 
 ## Table of contents
 
 - [Reporting a bug](#reporting-a-bug)
 - [Suggesting a feature](#suggesting-a-feature)
+- [Adding a portal](#adding-a-portal)
 - [Development setup](#development-setup)
 - [Testing locally](#testing-locally)
 - [Submitting a pull request](#submitting-a-pull-request)
@@ -25,6 +26,30 @@ Thank you for considering contributing to `veolia-api`! All contributions are we
 ## Suggesting a feature
 
 Open an issue with the `enhancement` label. Describe the use case and why it would benefit other users.
+
+---
+
+## Adding a portal
+
+This is the most common contribution. The only file to edit is **`veolia_api/portals.py`**:
+
+```python
+VEOLIA_PORTAL_CLIENTS: dict[str, str] = {
+    "eau.veolia.fr": "3kghade1fg54739kj8pkbova8j",
+    "eaudetm.monespace.eau.veolia.fr": "19bjc8ldefie683n889iiubjc8",
+    "monespace85.eau.veolia.fr": "55q97ufu391iajd22q9ed5qabe",
+    "your-portal.veolia.fr": "your-cognito-client-id",  # <-- add here
+}
+```
+
+Also update the **Supported portals** table in `README.md`.
+
+### How to find your client ID
+
+1. Open your Veolia portal login page in a browser
+2. Open the developer tools (F12) > **Network** tab
+3. Attempt to log in
+4. Look for a request to `cognito-idp.eu-west-3.amazonaws.com` — the `client_id` field in the request body is the value you need
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@
     <a href="https://github.com/Jezza34000/veolia-api/actions"><img src="https://github.com/Jezza34000/veolia-api/workflows/CI/badge.svg"/></a>
 </p>
 
-Async Python client for the Veolia water portal API (`eau.veolia.fr`).
+Async Python client for the Veolia water portal API (`eau.veolia.fr` and compatible portals).
 
 ## Table of contents
 
 - [Installation](#installation)
 - [Usage](#usage)
+- [Supported portals](#supported-portals)
 - [Contributing](#contributing)
 - [Credits](#credits)
 - [License](#license)
@@ -58,6 +59,9 @@ async def main() -> None:
     async with aiohttp.ClientSession() as session:
         client_api = VeoliaAPI("your@email.com", "password", session)
 
+        # Optional: specify a portal other than the default
+        # client_api = VeoliaAPI("your@email.com", "password", session, portal_url="monespace85.eau.veolia.fr")
+
         await client_api.fetch_all_data(date(2025, 1, 1), date(2025, 9, 1))
 
         # Display fetched data
@@ -72,6 +76,16 @@ if __name__ == "__main__":
 ```
 
 You can use usage_example.py
+
+## Supported portals
+
+| Portal | Region |
+|--------|--------|
+| `eau.veolia.fr` | France (national) |
+| `eaudetm.monespace.eau.veolia.fr` | Eau de Toulouse Métropole |
+| `monespace85.eau.veolia.fr` | Vendée Eau |
+
+Your portal is missing? See [Adding a portal](CONTRIBUTING.md#adding-a-portal) — it only requires editing one file.
 
 ## Contributing
 

--- a/usage_example.py
+++ b/usage_example.py
@@ -9,6 +9,7 @@ from datetime import date
 import aiohttp
 from dotenv import load_dotenv
 
+from veolia_api.portals import VEOLIA_PORTAL_CLIENTS
 from veolia_api.veolia_api import VeoliaAPI
 
 logging.basicConfig(
@@ -24,6 +25,7 @@ async def main() -> None:
 
     email = os.getenv("VEOLIA_EMAIL", "")
     password = os.getenv("VEOLIA_PASSWORD", "")
+    portal_url = os.getenv("VEOLIA_PORTAL_URL") or None
 
     if not email or not password:
         logger.error("VEOLIA_EMAIL and VEOLIA_PASSWORD must be set in .env file")
@@ -31,10 +33,11 @@ async def main() -> None:
         sys.exit(1)
 
     logger.info("Starting Veolia API example script")
+    logger.info("Available portals: %s", list(VEOLIA_PORTAL_CLIENTS))
 
     async with aiohttp.ClientSession() as session:
         logger.debug("Creating VeoliaAPI client")
-        client_api = VeoliaAPI(email, password, session)
+        client_api = VeoliaAPI(email, password, session, portal_url=portal_url)
 
         start_date = date(2025, 1, 1)
         end_date = date(2025, 9, 1)

--- a/veolia_api/constants.py
+++ b/veolia_api/constants.py
@@ -2,12 +2,15 @@
 
 from enum import Enum
 
+from .portals import VEOLIA_PORTAL_CLIENTS
+
 # URLS
 LOGIN_URL = "https://cognito-idp.eu-west-3.amazonaws.com"
 BACKEND_ISTEFR = "https://prd-ael-sirius-backend.istefr.fr"
 
 # AUTH
-LOGIN_CLIENT_ID = "3kghade1fg54739kj8pkbova8j"
+# Backward-compatibility alias / default portal (1st entry)
+LOGIN_CLIENT_ID = next(iter(VEOLIA_PORTAL_CLIENTS.values()))
 
 # API Flow Endpoints
 CALLBACK_ENDPOINT = "/callback"

--- a/veolia_api/portals.py
+++ b/veolia_api/portals.py
@@ -1,0 +1,14 @@
+"""
+Community-contributed Veolia portal instances.
+
+To add support for your portal, add an entry here:
+    "your-portal-hostname.veolia.fr": "your-cognito-client-id"
+
+The client_id can be found in the network traffic when logging in to your portal.
+"""
+
+VEOLIA_PORTAL_CLIENTS: dict[str, str] = {
+    "eau.veolia.fr": "3kghade1fg54739kj8pkbova8j",
+    "eaudetm.monespace.eau.veolia.fr": "19bjc8ldefie683n889iiubjc8",  # Eau de Toulouse Métropole
+    "monespace85.eau.veolia.fr": "55q97ufu391iajd22q9ed5qabe",  # Vendée Eau
+}

--- a/veolia_api/veolia_api.py
+++ b/veolia_api/veolia_api.py
@@ -31,11 +31,11 @@ from .constants import (
     BACKEND_ISTEFR,
     CONCURRENTS_TASKS,
     GET,
-    LOGIN_CLIENT_ID,
     LOGIN_URL,
     POST,
     TIMEOUT,
     TYPE_FRONT,
+    VEOLIA_PORTAL_CLIENTS,
     ConsumptionType,
 )
 from .model import AlertSettings, VeoliaAccountData
@@ -51,10 +51,22 @@ class VeoliaAPI:
         username: str,
         password: str,
         session: aiohttp.ClientSession | None = None,
+        portal_url: str | None = None,
     ) -> None:
         """Initialize the Veolia API client"""
         self.username = username
         self.password = password
+        portal = (
+            (portal_url or next(iter(VEOLIA_PORTAL_CLIENTS)))
+            .rstrip("/")
+            .removeprefix("https://")
+            .removeprefix("http://")
+        )
+        if portal not in VEOLIA_PORTAL_CLIENTS:
+            raise ValueError(
+                f"Unknown Veolia portal: {portal!r}. Add it to VEOLIA_PORTAL_CLIENTS in portals.py",
+            )
+        self._client_id = VEOLIA_PORTAL_CLIENTS[portal]
         self.account_data = VeoliaAccountData()
         self.session = session or aiohttp.ClientSession(timeout=TIMEOUT)
 
@@ -178,7 +190,7 @@ class VeoliaAPI:
         token_url = f"{LOGIN_URL}"
         _LOGGER.debug("Requesting access token...")
         json_payload = {
-            "ClientId": LOGIN_CLIENT_ID,
+            "ClientId": self._client_id,
             "AuthFlow": "USER_PASSWORD_AUTH",
             "AuthParameters": {"USERNAME": self.username, "PASSWORD": self.password},
         }


### PR DESCRIPTION
Multi-portal support (`portal_url`, `VEOLIA_PORTAL_CLIENTS`) was reverted in #30
on the assumption a single client_id worked for every portal. That's not the
case: `monespace85.eau.veolia.fr` (Vendée Eau) rejects the default client_id,
same as `eaudetm` did before the revert (see #35).

This PR:
- restores `veolia_api/portals.py` and the `portal_url` parameter on `VeoliaAPI`
- registers Vendée Eau's client_id (`55q97ufu391iajd22q9ed5qabe`), found in the
  portal's public front-end config and confirmed with a real login
- updates README / CONTRIBUTING / usage_example accordingly

Tested end-to-end with a real login against `monespace85.eau.veolia.fr`:
login, daily/monthly consumption, meter index, last reading date, and alert
settings (gracefully returns disabled, this portal doesn't expose
self-service consumption alerts).